### PR TITLE
Fix regex for selection input validation

### DIFF
--- a/xremap/install
+++ b/xremap/install
@@ -20,7 +20,7 @@ options=$(sed -nE "/name/s/.*\"(xremap.*zip)\".*/\1/p" xremaps.xml)
 nl <<<"$options"
 read -p "Which binary of xremap should I install in your system (Esc to skip)? " selection
 echo
-if [[ "$selection" =~ ^[0-9]$ ]]; then
+if [[ "$selection" =~ ^[0-9]+$ ]]; then
   binary_name=$(sed -n ${selection}p <<<"$options")
   echo "Downloading and installing $binary"
   binary_url=$(sed -nE "s/.*browser_download_url.*(https.*$binary_name)\".*/\1/p" xremaps.xml)


### PR DESCRIPTION
The selection regex only matches 0-9, but now there are >=10 options (mine was 10, the amd64 gnome one).